### PR TITLE
View hierarchy broken in iOS 7

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -132,6 +132,7 @@ secondStateIconName:(NSString *)secondIconName
     [_colorIndicatorView setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
     [_colorIndicatorView setBackgroundColor:[UIColor clearColor]];
     [self insertSubview:_colorIndicatorView atIndex:0];
+    self.backgroundColor = [UIColor clearColor];
 
     _slidingImageView = [[UIImageView alloc] init];
     [_slidingImageView setContentMode:UIViewContentModeCenter];


### PR DESCRIPTION
The colorIndicatorView is for some reason over the contentView of the cell. Changing the insertion to `[self insertSubview:_colorIndicatorView atIndex:0];` fixes the problem and makes this iOS 7 compatible.
