### PR TITLE
Fixed check for null images in slideImageWithPercentage method

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -412,31 +412,31 @@ secondStateIconName:(NSString *)secondIconName
     position.y = CGRectGetHeight(self.bounds) / 2.0;
     
     if (isDragging) {
-        if (percentage >= 0 && percentage < kMCStop1) {
-            position.x = [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
-        
-        else if (percentage >= kMCStop1) {
-            position.x = [self offsetWithPercentage:percentage - (kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
-        else if (percentage < 0 && percentage >= -kMCStop1) {
-            position.x = CGRectGetWidth(self.bounds) - [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
-        
-        else if (percentage < -kMCStop1) {
-            position.x = CGRectGetWidth(self.bounds) + [self offsetWithPercentage:percentage + (kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
+      if (percentage >= 0 && percentage < kMCStop1) {
+        position.x = [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
+      
+      else if (percentage >= kMCStop1) {
+        position.x = [self offsetWithPercentage:percentage - (kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
+      else if (percentage < 0 && percentage >= -kMCStop1) {
+        position.x = CGRectGetWidth(self.bounds) - [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
+      
+      else if (percentage < -kMCStop1) {
+        position.x = CGRectGetWidth(self.bounds) + [self offsetWithPercentage:percentage + (kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
     }
     else {
-        if (_direction == MCSwipeTableViewCellDirectionRight) {
-            position.x = [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
-        else if (_direction == MCSwipeTableViewCellDirectionLeft) {
-            position.x = CGRectGetWidth(self.bounds) - [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
-        }
-        else {
-            return;
-        }
+      if (_direction == MCSwipeTableViewCellDirectionRight) {
+        position.x = [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
+      else if (_direction == MCSwipeTableViewCellDirectionLeft) {
+        position.x = CGRectGetWidth(self.bounds) - [self offsetWithPercentage:(kMCStop1 / 2) relativeToWidth:CGRectGetWidth(self.bounds)];
+      }
+      else {
+        return;
+      }
     }
     
     
@@ -451,7 +451,7 @@ secondStateIconName:(NSString *)secondIconName
 
 - (void)moveWithDuration:(NSTimeInterval)duration andDirection:(MCSwipeTableViewCellDirection)direction {
     CGFloat origin;
-    
+  
     if (direction == MCSwipeTableViewCellDirectionLeft)
         origin = -CGRectGetWidth(self.bounds);
     else


### PR DESCRIPTION
The current slideImageWithPercentage method has one check to see if the
image is null in the animateWithOffset method, but not in the other
areas where slideImageWithPercentage is called.  This check to see if
the imageName is nil is added to suppress the following error:

CUICatalog: Invalid asset name supplied: (null), or invalid scale
factor: 2.000000

This error is a result of trying to perfrom actions on a UIImage that
has a null value.
