### PR TITLE
Used property getter for shouldDrag instead of ivar for more flexibility

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -255,7 +255,7 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
 
 - (void)handlePanGestureRecognizer:(UIPanGestureRecognizer *)gesture {
     
-    if (!_shouldDrag || _isExited) {
+    if (![self shouldDrag] || _isExited) {
         return;
     }
     


### PR DESCRIPTION
Instead of using the ivar `_shouldDrag`, I propose to use the property accessor instead.
This way, user can specify in his/her implementation easily if a cell can be swiped or not. 

User can just override the getter for shouldDrag in his custom MCSwipeTableViewCell implementation, then return a value based on the current state, e.g. return NO if table view is in edit mode (`self.isEditing` is YES). User does not need to manually set each cell's `_shouldDrag` value when edit mode has been set to YES (no need to loop through all cells then set new `_shouldDrag` value).

Any thoughts?
