### PR TITLE
Added flag to prevent any bounces

### DIFF
--- a/MCSwipe Demo/MCSwipe Demo/MCTableViewController.m
+++ b/MCSwipe Demo/MCSwipe Demo/MCTableViewController.m
@@ -9,7 +9,7 @@
 #import "MCSwipeTableViewCell.h"
 #import "MCTableViewController.h"
 
-static NSUInteger const kMCNumItems = 7;
+static NSUInteger const kMCNumItems = 8;
 
 @interface MCTableViewController () <MCSwipeTableViewCellDelegate, UIAlertViewDelegate>
 
@@ -97,7 +97,9 @@ static NSUInteger const kMCNumItems = 7;
     [cell setDefaultColor:self.tableView.backgroundView.backgroundColor];
     
     [cell setDelegate:self];
-    
+  
+    cell.bounces = YES;
+  
     if (indexPath.row % kMCNumItems == 0) {
         [cell.textLabel setText:@"Switch Mode Cell"];
         [cell.detailTextLabel setText:@"Swipe to switch"];
@@ -207,6 +209,16 @@ static NSUInteger const kMCNumItems = 7;
                                                       cancelButtonTitle:@"No"
                                                       otherButtonTitles:@"Yes", nil];
             [alertView show];
+        }];
+    }
+  
+    else if (indexPath.row % kMCNumItems == 7) {
+        cell.bounces = NO;
+      
+        [cell.textLabel setText:@"No bounces"];
+      
+        [cell setSwipeGestureWithView:checkView color:greenColor mode:MCSwipeTableViewCellModeSwitch state:MCSwipeTableViewCellState1 completionBlock:^(MCSwipeTableViewCell *cell, MCSwipeTableViewCellState state, MCSwipeTableViewCellMode mode) {
+            NSLog(@"Did swipe cell");
         }];
     }
 }

--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.h
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.h
@@ -151,6 +151,9 @@ typedef void (^MCSwipeCompletionBlock)(MCSwipeTableViewCell *cell, MCSwipeTableV
 /** Boolean to enable/disable the animation of the view during the swipe.  */
 @property (nonatomic, assign, readwrite) BOOL shouldAnimateIcons;
 
+/** Boolean to enable/disable the bounce when swiping if possible. Defaults to YES  */
+@property (nonatomic, assign, readwrite) BOOL bounces;
+
 /**
  *  Configures the properties of a cell.
  *


### PR DESCRIPTION
This add a "bounces" flag to MCSwipeTableViewCell.
This only change the behavior when only 2 of the 4 states are set, the user swipe in the right direction: when the flag is set to NO, swiping in the other direction won't allow the cell to bounce, and will stop at its position 0.
