### PR TITLE
Fixed a bug when start swiping a cell.

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -447,7 +447,7 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
     
     color = self.defaultColor ? self.defaultColor : [UIColor clearColor];
     
-    if (percentage > _firstTrigger && _modeForState1) {
+    if (percentage > 0 && _modeForState1) {
         color = _color1;
     }
     
@@ -455,7 +455,7 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
         color = _color2;
     }
     
-    if (percentage < -_firstTrigger && _modeForState3) {
+    if (percentage < 0 && _modeForState3) {
         color = _color3;
     }
     


### PR DESCRIPTION
Now when starting to swipe the cell, the swipping view appears immediately (before the first & second triggers positions)

Before the swipping hit the first trigger position this was happening:
![screen shot 2014-12-11 at 11 20 36 2](https://cloud.githubusercontent.com/assets/5262312/5393340/cff63704-8128-11e4-88d1-d01cecc2cc9f.png)

I'm using autolayout (yes, I know that this is not supported, but had no other problems, it's working really well) and did not check this issue without autolayout.
