### PR TITLE
Fix warnings from Xcode 6.3

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -333,7 +333,7 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
         UIPanGestureRecognizer *g = (UIPanGestureRecognizer *)gestureRecognizer;
         CGPoint point = [g velocityInView:self];
         
-        if (fabsf(point.x) > fabsf(point.y) ) {
+        if (fabs(point.x) > fabs(point.y) ) {
             if (point.x < 0 && !_modeForState3 && !_modeForState4) {
                 return NO;
             }
@@ -430,7 +430,7 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
     }
     
     else if (percentage < 0 && percentage > -_firstTrigger) {
-        alpha = fabsf(percentage / _firstTrigger);
+        alpha = fabs(percentage / _firstTrigger);
     }
     
     else {


### PR DESCRIPTION
"Absolute value function 'fabsf' given an argument of type 'CGFloat' (aka 'double') but has parameter of type 'float' which may cause truncation of value"

Auto-fix from Xcode was to use 'fabs' instead